### PR TITLE
remove pool size setting instead of sync.Pool runtime put-get interface;

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,16 @@
 module github.com/octu0/nats-pool
 
-go 1.13
+go 1.19
 
 require (
 	github.com/nats-io/nats-server/v2 v2.1.9
 	github.com/nats-io/nats.go v1.10.0
+)
+
+require (
+	github.com/nats-io/jwt v1.1.0 // indirect
+	github.com/nats-io/nkeys v0.1.4 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
+	golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59 // indirect
+	golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
+github.com/golang/protobuf v1.4.0 h1:oOuy+ugB+P/kBdUnG5QaMXSIyJ1q38wWSojYCb3z5VQ=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -25,6 +26,7 @@ golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e h1:D5TXcfTk7xF7hvieo4QErS3qqCB4teTffacDWr7CI+0=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -33,4 +35,5 @@ google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
+google.golang.org/protobuf v1.22.0 h1:cJv5/xdbk1NnMPR1VP9+HU6gupuG9MLBoH1r6RHZ2MY=
 google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=

--- a/pool_test.go
+++ b/pool_test.go
@@ -3,7 +3,6 @@ package pool
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -40,71 +39,6 @@ func testStartNatsd(port int) (*server.Server, error) {
 	return ns, nil
 }
 
-func BenchmarkSimpleConnPubSub(b *testing.B) {
-	test := func(wg *sync.WaitGroup, nc *nats.Conn, id string, tb *testing.B, end func(nc *nats.Conn)) {
-		defer wg.Done()
-		defer end(nc)
-
-		done := make(chan struct{})
-		subj := "hello.workd" + id
-		sub, err := nc.Subscribe(subj, func(msg *nats.Msg) {
-			if string(msg.Data) != "foobar" {
-				tb.Errorf("msg.Data not != foobar : %s", string(msg.Data))
-			}
-			done <- struct{}{}
-		})
-		if err != nil {
-			tb.Errorf(err.Error())
-			return
-		}
-
-		go nc.Publish(subj, []byte("foobar"))
-		<-done
-		sub.Unsubscribe()
-	}
-	b.Run("NoPool", func(tb *testing.B) {
-		ns, err := testStartNatsd(-1)
-		if err != nil {
-			panic(err)
-		}
-
-		wg := new(sync.WaitGroup)
-		url := fmt.Sprintf("nats://%s", ns.Addr().String())
-		for i := 0; i < tb.N; i += 1 {
-			nc, err := nats.Connect(url)
-			if err != nil {
-				tb.Errorf(err.Error())
-			}
-			wg.Add(1)
-			go test(wg, nc, strconv.Itoa(i), tb, func(_nc *nats.Conn) {
-				_nc.Close()
-			})
-		}
-		wg.Wait()
-	})
-	b.Run("UsePool", func(tb *testing.B) {
-		ns, err := testStartNatsd(-1)
-		if err != nil {
-			panic(err)
-		}
-
-		wg := new(sync.WaitGroup)
-		url := fmt.Sprintf("nats://%s", ns.Addr().String())
-		p := New(100, url)
-		for i := 0; i < tb.N; i += 1 {
-			nc, err := p.Get()
-			if err != nil {
-				tb.Errorf(err.Error())
-			}
-			wg.Add(1)
-			go test(wg, nc, strconv.Itoa(i), tb, func(_nc *nats.Conn) {
-				p.Put(_nc)
-			})
-		}
-		wg.Wait()
-	})
-}
-
 func TestNew(t *testing.T) {
 	ns, err := testStartNatsd(-1)
 	if err != nil {
@@ -114,41 +48,20 @@ func TestNew(t *testing.T) {
 
 	url := fmt.Sprintf("nats://%s", ns.Addr().String())
 	t.Run("default", func(tt *testing.T) {
-		p := New(10, url)
-		nc, err := p.Get()
+		p := New(url)
+		_, err := p.Get()
 		if err != nil {
 			tt.Errorf("no error to Get(): %s", err.Error())
 		}
-		if nc.Opts.Name != "" {
-			tt.Errorf("using default option: %s", nc.Opts.Name)
-		}
-		if p.Len() != 0 {
-			tt.Errorf("initial len = 0")
-		}
-		if p.Cap() != 10 {
-			tt.Errorf("initial cap = 10")
-		}
 	})
 	t.Run("withOption", func(tt *testing.T) {
-		p := New(10, url,
+		p := New(url,
 			nats.Name("hello world"),
 			nats.NoEcho(),
 		)
-		nc, err := p.Get()
+		_, err := p.Get()
 		if err != nil {
 			tt.Errorf("no error to Get() w/ options: %s", err.Error())
-		}
-		if nc.Opts.Name != "hello world" {
-			tt.Errorf("option w/ name: %s", nc.Opts.Name)
-		}
-		if nc.Opts.NoEcho != true {
-			tt.Errorf("option w/ NoEcho: %v", nc.Opts.NoEcho)
-		}
-		if p.Len() != 0 {
-			tt.Errorf("initial len = 0")
-		}
-		if p.Cap() != 10 {
-			tt.Errorf("initial cap = 10")
 		}
 	})
 }
@@ -162,61 +75,18 @@ func TestGetPut(t *testing.T) {
 
 	url := fmt.Sprintf("nats://%s", ns.Addr().String())
 	t.Run("getput", func(tt *testing.T) {
-		p := New(10, url)
-		nc1, err1 := p.Get()
-		if err1 != nil {
-			tt.Errorf(err1.Error())
-		}
-		if nc1.IsConnected() != true {
-			tt.Errorf("connected only")
-		}
-		ok1, err2 := p.Put(nc1)
-		if ok1 != true {
-			tt.Errorf("put ok / free cap")
-		}
-		if err2 != nil {
-			tt.Errorf(err2.Error())
-		}
-		if p.Len() != 1 {
-			tt.Errorf("p.Len() == 1: %d", p.Len())
-		}
-	})
-	t.Run("put/maxcap", func(tt *testing.T) {
-		p := New(10, url)
-		n := make([]*nats.Conn, 10)
-		for i := 0; i < 10; i += 1 {
-			nc, err := p.Get()
-			if err != nil {
-				tt.Errorf(err.Error())
-			}
-			n[i] = nc
-		}
-		for _, nc := range n {
-			ok, err := p.Put(nc)
-			if ok != true {
-				tt.Errorf("put ok / free cap")
-			}
-			if err != nil {
-				tt.Errorf(err.Error())
-			}
-		}
-		if p.Len() != 10 {
-			tt.Errorf("len == 10")
+		p := New(url)
+		nc1, err := p.Get()
+		if err != nil {
+			tt.Errorf(err.Error())
 		}
 
-		nc1, err1 := p.connect()
-		if err1 != nil {
-			tt.Errorf(err1.Error())
+		if nc1.Conn.IsConnected() != true {
+			tt.Errorf("connected only")
 		}
-		ok, err2 := p.Put(nc1)
-		if ok {
-			tt.Errorf("discard / max cap")
-		}
-		if err2 != nil {
-			tt.Errorf(err2.Error())
-		}
-		if nc1.IsConnected() {
-			tt.Errorf("closed")
+
+		if err := p.Put(nc1); err != nil {
+			tt.Errorf("put ok / free cap")
 		}
 	})
 }
@@ -230,8 +100,8 @@ func TestPool(t *testing.T) {
 		defer ns.Shutdown()
 
 		url := fmt.Sprintf("nats://%s", ns.Addr().String())
-		p := New(10, url)
-		n := make([]*nats.Conn, 10)
+		p := New(url)
+		n := make([]*nats.EncodedConn, 10)
 		for i := 0; i < 10; i += 1 {
 			nc, err := p.Get()
 			if err != nil {
@@ -239,47 +109,6 @@ func TestPool(t *testing.T) {
 			}
 			n[i] = nc
 		}
-
-		if ns.NumClients() != 10 {
-			tt.Errorf("server client 10: %d", ns.NumClients())
-		}
-	})
-	t.Run("getput/conn10", func(tt *testing.T) {
-		ns, err := testStartNatsd(-1)
-		if err != nil {
-			panic(err)
-		}
-		defer ns.Shutdown()
-
-		url := fmt.Sprintf("nats://%s", ns.Addr().String())
-		p := New(10, url)
-		n := make([]*nats.Conn, 10)
-		for i := 0; i < 10; i += 1 {
-			nc, err := p.Get()
-			if err != nil {
-				tt.Errorf(err.Error())
-			}
-			n[i] = nc
-		}
-
-		for _, nc := range n {
-			p.Put(nc)
-		}
-
-		if ns.NumClients() != 10 {
-			tt.Errorf("server client 10: %d", ns.NumClients())
-		}
-
-		nc, err := p.Get()
-		if err != nil {
-			tt.Errorf(err.Error())
-		}
-
-		if ns.NumClients() != 10 {
-			tt.Errorf("server client 10: %d", ns.NumClients())
-		}
-
-		p.Put(nc)
 
 		if ns.NumClients() != 10 {
 			tt.Errorf("server client 10: %d", ns.NumClients())
@@ -295,141 +124,41 @@ func TestClosedConn(t *testing.T) {
 	defer ns.Shutdown()
 
 	url := fmt.Sprintf("nats://%s", ns.Addr().String())
-	p := New(10, url)
+	p := New(url)
 	nc, err := p.Get()
 	if err != nil {
 		t.Errorf(err.Error())
 	}
+
 	nc.Close()
-	ok, err := p.Put(nc)
-	if err != nil {
+	if err := p.Put(nc); err != nil {
 		t.Errorf(err.Error())
 	}
-	if ok != true {
-		t.Errorf("free cap")
-	}
+
 	nc1, err1 := p.Get()
 	if err1 != nil {
 		t.Errorf(err1.Error())
 	}
-	if nc1.IsConnected() != true {
+	if !nc1.Conn.IsConnected() {
 		t.Errorf("new conn is connected")
 	}
 }
 
-func TestLeakSubs(t *testing.T) {
-	ns, err := testStartNatsd(-1)
-	if err != nil {
-		panic(err)
-	}
-	defer ns.Shutdown()
-
-	url := fmt.Sprintf("nats://%s", ns.Addr().String())
-	p := New(10, url)
-	nc, err := p.Get()
-	if err != nil {
-		t.Errorf(err.Error())
-	}
-	sub, err := nc.Subscribe("foo.bar", func(msg *nats.Msg) {
-		if "hello world" != string(msg.Data) {
-			t.Errorf("data == 'hello world': %v", msg.Data)
-		}
-	})
-	if err != nil {
-		t.Errorf(err.Error())
-	}
-	if nc.NumSubscriptions() != 1 {
-		t.Errorf("sub 1")
-	}
-
-	nc.Publish("foo.bar", []byte("hello world"))
-
-	p.Put(nc)
-
-	if nc.NumSubscriptions() != 1 {
-		t.Errorf("leaked sub")
-	}
-	if sub.IsValid() != true {
-		t.Errorf("released but keep connection")
-	}
-	sub.Unsubscribe()
-	if nc.NumSubscriptions() != 0 {
-		t.Errorf("unscribed")
-	}
-}
-
 func TestDisconnectAll(t *testing.T) {
-	t.Run("newclient", func(tt *testing.T) {
-		ns, err := testStartNatsd(-1)
-		if err != nil {
-			panic(err)
-		}
-		defer ns.Shutdown()
-
-		url := fmt.Sprintf("nats://%s", ns.Addr().String())
-		p := New(10, url)
-
-		ncs := make([]*nats.Conn, 10)
-		for i := 0; i < 10; i += 1 {
-			nc, err := p.Get()
-			if err != nil {
-				tt.Errorf(err.Error())
-			}
-			ncs[i] = nc
-		}
-
-		lastClientId := uint64(0)
-		for _, nc := range ncs {
-			id, err := nc.GetClientID()
-			if err != nil {
-				tt.Errorf(err.Error())
-			}
-			lastClientId = id
-			p.Put(nc)
-		}
-
-		nc1, err := p.Get()
-		if err != nil {
-			t.Errorf(err.Error())
-		}
-		id1, err := nc1.GetClientID()
-		if err != nil {
-			t.Errorf(err.Error())
-		}
-		if lastClientId < id1 {
-			tt.Errorf("use exists conn")
-		}
-		p.Put(nc1)
-
-		p.DisconnectAll()
-
-		nc2, err := p.Get()
-		if err != nil {
-			tt.Errorf(err.Error())
-		}
-		id2, err := nc2.GetClientID()
-		if err != nil {
-			tt.Errorf(err.Error())
-		}
-		p.Put(nc2)
-
-		if id2 <= lastClientId {
-			tt.Errorf("new client")
-		}
-	})
 	t.Run("concurrency", func(tt *testing.T) {
 		// all no error
-
 		ns, err := testStartNatsd(-1)
 		if err != nil {
 			panic(err)
 		}
 		defer ns.Shutdown()
 
-		url := fmt.Sprintf("nats://%s", ns.Addr().String())
-		p := New(100, url)
-		boot := new(sync.WaitGroup)
 		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		url := fmt.Sprintf("nats://%s", ns.Addr().String())
+		p := New(url)
+		boot := new(sync.WaitGroup)
 		for i := 0; i < 100; i += 1 {
 			boot.Add(1)
 			go func(c context.Context, cp *ConnPool, b *sync.WaitGroup) {
@@ -450,12 +179,5 @@ func TestDisconnectAll(t *testing.T) {
 			}(ctx, p, boot)
 		}
 		boot.Wait()
-
-		time.Sleep(time.Second) // warmimng-up workers
-		for i := 0; i < 100; i += 1 {
-			p.DisconnectAll()
-			time.Sleep(50 * time.Millisecond) // save high load for ci
-		}
-		cancel()
 	})
 }


### PR DESCRIPTION
We found a situation in which your solution proved to be useful.
But limiting the size of the connection pool would be cumbersome for us.
Therefore, we have replaced this setting with sync.Pool.